### PR TITLE
Apply the new `innerHTML` only if the text have actually changed

### DIFF
--- a/js/jenkins-terminal-colors.js
+++ b/js/jenkins-terminal-colors.js
@@ -8,7 +8,18 @@ $(document).ready(function() {
         return text;
     }
 
-    setInterval(function() {
-        $('pre').get(0).innerHTML = transformText($('pre').get(0).innerHTML);
-    }, 200);
+    function reformatExecute()
+        var pre_element = $('pre').get(0);
+
+        var original_inner_html = pre_element.innerHTML;
+        var reformated_inner_html = transformText(original_inner_html);
+
+        // Only update the content if it actually changed.
+        // The transformations in `transformText` will increase the text length if any happened.
+        var text_changed = (original_inner_html.length != reformated_inner_html.length);
+        if (text_changed) pre_element.innerHTML = reformated_inner_html;
+
+        pre_element = original_inner_html = reformated_inner_html = text_changed = undefined;
+    }
+    setInterval(reformatExecute, 200);
 });

--- a/js/jenkins-terminal-colors.js
+++ b/js/jenkins-terminal-colors.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
         return text;
     }
 
-    function reformatExecute()
+    function reformatExecute() {
         var pre_element = $('pre').get(0);
 
         var original_inner_html = pre_element.innerHTML;
@@ -17,7 +17,7 @@ $(document).ready(function() {
         // Only update the content if it actually changed.
         // The transformations in `transformText` will increase the text length if any happened.
         var text_changed = (original_inner_html.length != reformated_inner_html.length);
-        if (text_changed){
+        if (text_changed) {
             pre_element.innerHTML = reformated_inner_html;
         }
     }

--- a/js/jenkins-terminal-colors.js
+++ b/js/jenkins-terminal-colors.js
@@ -17,9 +17,9 @@ $(document).ready(function() {
         // Only update the content if it actually changed.
         // The transformations in `transformText` will increase the text length if any happened.
         var text_changed = (original_inner_html.length != reformated_inner_html.length);
-        if (text_changed) pre_element.innerHTML = reformated_inner_html;
-
-        pre_element = original_inner_html = reformated_inner_html = text_changed = undefined;
+        if (text_changed){
+            pre_element.innerHTML = reformated_inner_html;
+        }
     }
     setInterval(reformatExecute, 200);
 });


### PR DESCRIPTION
This will avoid unnecessary HTML parses and DOM rendering.

It is intended as a partial solution to #2.

It does not fully address the problem in that issue since when new content arrives it is possible that the selection is lost.
But it offers a performance improvement when the contents of the console are massive due to reduced HTML parsing and DOM re-rendering.
