### PR TITLE
Add selectors and styles for Jenkins 1.576 UI refresh

### DIFF
--- a/css/jenkins-terminal-colors.css
+++ b/css/jenkins-terminal-colors.css
@@ -2,7 +2,13 @@
 Colors from (dark) Solarized : http://ethanschoonover.com/solarized
 */
 
-#main-table #main-panel {
+#main-table #main-panel,
+#main-panel #main-panel-content {
   background-color: #002b36;
   color: #839496;
+}
+
+#main-panel #main-panel-content {
+  margin: 0;
+  padding: 15px;
 }


### PR DESCRIPTION
## What problem does this PR solve?

After updating Jenkins to versions after 1.576, the selectors in the CSS of this plugin weren't targeting the new UI's console pane.

The Jenkins UI was refreshed in this release [as per the announcement on their blog](https://jenkins.io/blog/2014/08/11/user-interface-refresh/), and with it, some of the class names and ids changed in the markup.

This plugin's great, and I got so used to seeing Jenkins console logs in Solarized Dark that when we updated to 1.576 I found it a quite jarring.

![image](https://cloud.githubusercontent.com/assets/1752124/23058979/afbbed7c-f4f7-11e6-9fee-a02649259964.png)

## Solution

* Add the new selectors (rather than replace the old ones) for backwards compatibility
* Switch the left and right margins with padding to give the text some room to breath and make it easier to read

![image](https://cloud.githubusercontent.com/assets/1752124/23058993/ba7de6ac-f4f7-11e6-960e-5d46c355f36d.png)
